### PR TITLE
add ability to sync an egg startup command to its servers

### DIFF
--- a/.sqlx/query-5bcc785863690187a3635c61603731d7bedcd483ad377d6e604ed49dff42c1fe.json
+++ b/.sqlx/query-5bcc785863690187a3635c61603731d7bedcd483ad377d6e604ed49dff42c1fe.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE servers\n                SET startup = $2\n                WHERE servers.uuid = ANY($1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5bcc785863690187a3635c61603731d7bedcd483ad377d6e604ed49dff42c1fe"
+}

--- a/backend/src/routes/api/admin/nests/_nest_/eggs/_egg_/mod.rs
+++ b/backend/src/routes/api/admin/nests/_nest_/eggs/_egg_/mod.rs
@@ -18,6 +18,7 @@ mod export;
 mod mounts;
 mod r#move;
 mod servers;
+mod sync_startup;
 mod update;
 mod variables;
 
@@ -265,6 +266,7 @@ pub fn router(state: &State) -> OpenApiRouter<State> {
         .routes(routes!(delete::route))
         .routes(routes!(patch::route))
         .nest("/servers", servers::router(state))
+        .nest("/sync-startup", sync_startup::router(state))
         .nest("/update", update::router(state))
         .nest("/variables", variables::router(state))
         .nest("/move", r#move::router(state))

--- a/backend/src/routes/api/admin/nests/_nest_/eggs/_egg_/sync_startup.rs
+++ b/backend/src/routes/api/admin/nests/_nest_/eggs/_egg_/sync_startup.rs
@@ -1,0 +1,126 @@
+use super::State;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+mod post {
+    use crate::routes::api::admin::nests::_nest_::{GetNest, eggs::_egg_::GetNestEgg};
+    use axum::http::StatusCode;
+    use garde::Validate;
+    use serde::{Deserialize, Serialize};
+    use shared::{
+        ApiError, GetState,
+        models::{
+            admin_activity::GetAdminActivityLogger, server::Server, user::GetPermissionManager,
+        },
+        response::{ApiResponse, ApiResponseResult},
+    };
+    use utoipa::ToSchema;
+
+    #[derive(ToSchema, Validate, Deserialize)]
+    pub struct Payload {
+        /// The startup command to apply, has to be one of the egg's startup commands.
+        #[garde(length(chars, min = 1, max = 8192))]
+        #[schema(min_length = 1, max_length = 8192)]
+        startup: compact_str::CompactString,
+    }
+
+    #[derive(ToSchema, Serialize)]
+    struct Response {
+        /// Amount of servers that were updated.
+        synced: usize,
+    }
+
+    #[utoipa::path(post, path = "/", responses(
+        (status = OK, body = inline(Response)),
+        (status = BAD_REQUEST, body = ApiError),
+        (status = NOT_FOUND, body = ApiError),
+        (status = EXPECTATION_FAILED, body = ApiError),
+    ), params(
+        (
+            "nest" = uuid::Uuid,
+            description = "The nest ID",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+        ),
+        (
+            "egg" = uuid::Uuid,
+            description = "The egg ID",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+        ),
+    ), request_body = inline(Payload))]
+    pub async fn route(
+        state: GetState,
+        permissions: GetPermissionManager,
+        nest: GetNest,
+        egg: GetNestEgg,
+        activity_logger: GetAdminActivityLogger,
+        shared::Payload(data): shared::Payload<Payload>,
+    ) -> ApiResponseResult {
+        if let Err(errors) = shared::utils::validate_data(&data) {
+            return ApiResponse::new_serialized(ApiError::new_strings_value(errors))
+                .with_status(StatusCode::BAD_REQUEST)
+                .ok();
+        }
+
+        permissions.has_admin_permission("servers.update")?;
+
+        if !egg
+            .startup_commands
+            .values()
+            .any(|command| command == data.startup)
+        {
+            return ApiResponse::error("startup command is not defined on this egg")
+                .with_status(StatusCode::EXPECTATION_FAILED)
+                .ok();
+        }
+
+        // ponytail: loads every server of the egg to sync it with wings afterwards, which needs the
+        // full model. Chunk this if an egg ever holds more servers than comfortably fit in memory.
+        let targets: Vec<Server> = Server::all_by_egg_uuid(&state.database, egg.uuid)
+            .await?
+            .into_iter()
+            .filter(|server| server.startup != data.startup)
+            .collect();
+
+        if !targets.is_empty() {
+            let uuids: Vec<uuid::Uuid> = targets.iter().map(|server| server.uuid).collect();
+
+            sqlx::query!(
+                "UPDATE servers
+                SET startup = $2
+                WHERE servers.uuid = ANY($1)",
+                &uuids,
+                data.startup.as_str()
+            )
+            .execute(state.database.write())
+            .await?;
+        }
+
+        activity_logger
+            .log(
+                "nest:egg.sync-startup",
+                serde_json::json!({
+                    "uuid": egg.uuid,
+                    "nest_uuid": nest.uuid,
+
+                    "name": egg.name,
+                    "startup": data.startup,
+
+                    "synced": targets.len(),
+                }),
+            )
+            .await;
+
+        let synced = targets.len();
+        for mut server in targets {
+            server.startup = data.startup.clone();
+            server.batch_sync(&state.database).await;
+        }
+
+        ApiResponse::new_serialized(Response { synced }).ok()
+    }
+}
+
+pub fn router(state: &State) -> OpenApiRouter<State> {
+    OpenApiRouter::new()
+        .routes(routes!(post::route))
+        .with_state(state.clone())
+}

--- a/frontend/public/translations/en.json
+++ b/frontend/public/translations/en.json
@@ -336,6 +336,8 @@
         "destination": "Destination",
         "destinationDirectory": "Destination Directory",
         "directoryName": "Directory Name",
+        "symlinkName": "Symlink Name",
+        "symlinkTarget": "Symlink Target",
         "locked": "Locked",
         "portRanges": "Port Ranges",
         "portRangesPlaceholder": "Port Ranges (eg. 3000-4000)",
@@ -3297,16 +3299,25 @@
                       "emptyReplacements": "No replacements defined.",
                       "button": {
                         "addReplacement": "Add Replacement",
-                        "addConfigFile": "Add Config File"
+                        "addConfigFile": "Add Config File",
+                        "syncStartup": "Sync to Servers"
                       },
                       "toast": {
                         "exported": "Egg exported.",
-                        "updated": "Egg updated."
+                        "updated": "Egg updated.",
+                        "startupSynced": "Startup command applied to {servers}."
                       },
                       "modal": {
                         "delete": {
                           "title": "Confirm Egg Deletion",
                           "content": "Are you sure you want to delete **{name}**?"
+                        },
+                        "syncStartup": {
+                          "title": "Sync Startup Command to Servers",
+                          "alert": {
+                            "unsavedChanges": "The startup commands have unsaved changes. Save the egg first, otherwise the old command would be synced.",
+                            "overwritesEverything": "This applies the selected command to every server using this egg. Servers running a different command of this egg, as well as individually customized startup commands, will be replaced and cannot be restored."
+                          }
                         }
                       }
                     }
@@ -4581,6 +4592,7 @@
             "exitBackup": "Exit Backup",
             "fileFromEditor": "File from Editor",
             "directory": "Directory",
+            "symlink": "Symlink",
             "fileFromPull": "File from Pull",
             "fileFromUpload": "File from Upload",
             "directoryFromUpload": "Directory from Upload",
@@ -4756,6 +4768,12 @@
             "createDirectory": {
               "title": "Create Directory",
               "createdAs": "This directory will be created as "
+            },
+            "createSymlink": {
+              "title": "Create Symlink",
+              "targetDescription": "Relative to the directory the symlink is created in.",
+              "createdAs": "This symlink will be created as ",
+              "pointsTo": "It will point to "
             },
             "copyFile": {
               "title": "Copy File",

--- a/frontend/src/api/admin/nests/eggs/syncEggStartup.ts
+++ b/frontend/src/api/admin/nests/eggs/syncEggStartup.ts
@@ -1,0 +1,8 @@
+import { axiosInstance } from '@/api/axios.ts';
+
+export default async (nestUuid: string, eggUuid: string, startup: string): Promise<{ synced: number }> => {
+  const { data } = await axiosInstance.post(`/api/admin/nests/${nestUuid}/eggs/${eggUuid}/sync-startup`, {
+    startup,
+  });
+  return data;
+};

--- a/frontend/src/pages/admin/nests/eggs/EggCreateOrUpdate.tsx
+++ b/frontend/src/pages/admin/nests/eggs/EggCreateOrUpdate.tsx
@@ -7,6 +7,7 @@ import {
   faPlay,
   faPlus,
   faRefresh,
+  faRotate,
   faStop,
   faUpload,
 } from '@fortawesome/free-solid-svg-icons';
@@ -55,6 +56,7 @@ import { useToast } from '@/providers/ToastProvider.tsx';
 import { useTranslations } from '@/providers/TranslationProvider.tsx';
 import EggDuplicateModal from './modals/EggDuplicateModal.tsx';
 import EggMoveModal from './modals/EggMoveModal.tsx';
+import EggSyncStartupModal from './modals/EggSyncStartupModal.tsx';
 import EggUpdateUrlModal from './modals/EggUpdateUrlModal.tsx';
 
 export default function EggCreateOrUpdate({
@@ -68,7 +70,10 @@ export default function EggCreateOrUpdate({
   const { t } = useTranslations();
 
   const [isValid, setIsValid] = useState(false);
-  const [openModal, setOpenModal] = useState<'move' | 'delete' | 'duplicate' | 'updateUrl' | null>(null);
+  const [openModal, setOpenModal] = useState<'move' | 'delete' | 'duplicate' | 'updateUrl' | 'syncStartup' | null>(
+    null,
+  );
+  const [startupCommandsDirty, setStartupCommandsDirty] = useState(false);
   const [selectedEggRepositoryUuid, setSelectedEggRepositoryUuid] = useState<string>(
     contextEgg?.eggRepositoryEgg?.eggRepository.uuid ?? '',
   );
@@ -287,6 +292,15 @@ export default function EggCreateOrUpdate({
           onClose={() => setOpenModal(null)}
           nest={contextNest}
           egg={contextEgg}
+        />
+      )}
+      {contextEgg && (
+        <EggSyncStartupModal
+          opened={openModal === 'syncStartup'}
+          onClose={() => setOpenModal(null)}
+          nest={contextNest}
+          egg={contextEgg}
+          hasUnsavedChanges={startupCommandsDirty}
         />
       )}
       {contextEgg && (
@@ -656,12 +670,32 @@ export default function EggCreateOrUpdate({
             </Button>
           </TitleCard>
 
-          <MultiKeyValueInput
-            label={t('pages.admin.nests.tabs.eggs.page.tabs.general.page.form.startupCommands', {})}
-            withAsterisk
-            options={form.getValues().startupCommands}
-            onChange={(e) => form.setFieldValue('startupCommands', e)}
-          />
+          <Stack gap='xs'>
+            <MultiKeyValueInput
+              label={t('pages.admin.nests.tabs.eggs.page.tabs.general.page.form.startupCommands', {})}
+              withAsterisk
+              options={form.getValues().startupCommands}
+              onChange={(e) => form.setFieldValue('startupCommands', e)}
+            />
+
+            {contextEgg && (
+              <AdminCan action='servers.update'>
+                <Button
+                  variant='light'
+                  className='w-fit!'
+                  leftSection={<FontAwesomeIcon icon={faRotate} />}
+                  onClick={() => {
+                    setStartupCommandsDirty(
+                      JSON.stringify(form.getValues().startupCommands) !== JSON.stringify(contextEgg.startupCommands),
+                    );
+                    setOpenModal('syncStartup');
+                  }}
+                >
+                  {t('pages.admin.nests.tabs.eggs.page.tabs.general.page.button.syncStartup', {})}
+                </Button>
+              </AdminCan>
+            )}
+          </Stack>
 
           <Group grow>
             <Switch

--- a/frontend/src/pages/admin/nests/eggs/modals/EggSyncStartupModal.tsx
+++ b/frontend/src/pages/admin/nests/eggs/modals/EggSyncStartupModal.tsx
@@ -1,0 +1,95 @@
+import { ModalProps } from '@mantine/core';
+import { FormEvent, useEffect, useState } from 'react';
+import { z } from 'zod';
+import syncEggStartup from '@/api/admin/nests/eggs/syncEggStartup.ts';
+import { httpErrorToHuman } from '@/api/axios.ts';
+import Alert from '@/elements/Alert.tsx';
+import Button from '@/elements/Button.tsx';
+import Select from '@/elements/input/Select.tsx';
+import FormModal from '@/elements/modals/FormModal.tsx';
+import { ModalFooter } from '@/elements/modals/Modal.tsx';
+import Stack from '@/elements/Stack.tsx';
+import { adminEggSchema } from '@/lib/schemas/admin/eggs.ts';
+import { adminNestSchema } from '@/lib/schemas/admin/nests.ts';
+import { useToast } from '@/providers/ToastProvider.tsx';
+import { useTranslations } from '@/providers/TranslationProvider.tsx';
+
+export default function EggSyncStartupModal({
+  nest,
+  egg,
+  hasUnsavedChanges,
+  ...props
+}: ModalProps & {
+  nest: z.infer<typeof adminNestSchema>;
+  egg: z.infer<typeof adminEggSchema>;
+  hasUnsavedChanges: boolean;
+}) {
+  const { t, tItem } = useTranslations();
+  const { addToast } = useToast();
+
+  const [loading, setLoading] = useState(false);
+  const [startup, setStartup] = useState('');
+
+  useEffect(() => {
+    setStartup(egg.startupCommands['Default'] || Object.values(egg.startupCommands)[0] || '');
+  }, [egg, props.opened]);
+
+  const doSync = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+
+    syncEggStartup(nest.uuid, egg.uuid, startup)
+      .then(({ synced }) => {
+        addToast(
+          t('pages.admin.nests.tabs.eggs.page.tabs.general.page.toast.startupSynced', {
+            servers: tItem('server', synced),
+          }),
+          'success',
+        );
+        props.onClose();
+      })
+      .catch((msg) => addToast(httpErrorToHuman(msg), 'error'))
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <FormModal
+      title={t('pages.admin.nests.tabs.eggs.page.tabs.general.page.modal.syncStartup.title', {})}
+      loading={loading}
+      {...props}
+      onSubmit={doSync}
+    >
+      <Stack>
+        {hasUnsavedChanges && (
+          <Alert color='yellow'>
+            {t('pages.admin.nests.tabs.eggs.page.tabs.general.page.modal.syncStartup.alert.unsavedChanges', {})}
+          </Alert>
+        )}
+
+        <Select
+          withAsterisk
+          label={t('common.form.startupCommand', {})}
+          value={startup}
+          onChange={(value) => setStartup(value ?? '')}
+          data={Object.entries(egg.startupCommands).map(([key, value]) => ({
+            label: key,
+            value,
+          }))}
+        />
+
+        <Alert color='red'>
+          {t('pages.admin.nests.tabs.eggs.page.tabs.general.page.modal.syncStartup.alert.overwritesEverything', {})}
+        </Alert>
+
+        <ModalFooter>
+          <Button type='submit' color='red' loading={loading} disabled={!startup || hasUnsavedChanges}>
+            {t('pages.admin.nests.tabs.eggs.page.tabs.general.page.button.syncStartup', {})}
+          </Button>
+          <Button variant='default' onClick={props.onClose}>
+            {t('common.button.close', {})}
+          </Button>
+        </ModalFooter>
+      </Stack>
+    </FormModal>
+  );
+}

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -3265,15 +3265,26 @@ const baseTranslations = defineTranslations({
                       button: {
                         addReplacement: 'Add Replacement',
                         addConfigFile: 'Add Config File',
+                        syncStartup: 'Sync to Servers',
                       },
                       toast: {
                         exported: 'Egg exported.',
                         updated: 'Egg updated.',
+                        startupSynced: 'Startup command applied to {servers}.',
                       },
                       modal: {
                         delete: {
                           title: 'Confirm Egg Deletion',
                           content: 'Are you sure you want to delete **{name}**?',
+                        },
+                        syncStartup: {
+                          title: 'Sync Startup Command to Servers',
+                          alert: {
+                            unsavedChanges:
+                              'The startup commands have unsaved changes. Save the egg first, otherwise the old command would be synced.',
+                            overwritesEverything:
+                              'This applies the selected command to every server using this egg. Servers running a different command of this egg, as well as individually customized startup commands, will be replaced and cannot be restored.',
+                          },
                         },
                       },
                     },

--- a/shared/src/models/server/mod.rs
+++ b/shared/src/models/server/mod.rs
@@ -893,6 +893,36 @@ impl Server {
         })
     }
 
+    /// Fetches every server using the given egg. Unlike [`by_egg_uuid_with_pagination`](Self::by_egg_uuid_with_pagination)
+    /// this is not paginated, it is meant for bulk operations that have to touch all of an egg's servers.
+    pub async fn all_by_egg_uuid(
+        database: &crate::database::Database,
+        egg_uuid: uuid::Uuid,
+    ) -> Result<Vec<Self>, crate::database::DatabaseError> {
+        let rows = sqlx::query(sqlx::AssertSqlSafe(format!(
+            r#"
+            SELECT {}
+            FROM servers
+            LEFT JOIN server_allocations ON server_allocations.uuid = servers.allocation_uuid
+            LEFT JOIN node_allocations ON node_allocations.uuid = server_allocations.allocation_uuid
+            JOIN users ON users.uuid = servers.owner_uuid
+            LEFT JOIN roles ON roles.uuid = users.role_uuid
+            JOIN nest_eggs ON nest_eggs.uuid = servers.egg_uuid
+            JOIN nests ON nests.uuid = nest_eggs.nest_uuid
+            WHERE servers.egg_uuid = $1
+            ORDER BY servers.created
+            "#,
+            Self::columns_sql(None)
+        )))
+        .bind(egg_uuid)
+        .fetch_all(database.read())
+        .await?;
+
+        rows.into_iter()
+            .map(|row| Self::map(None, &row))
+            .try_collect_vec()
+    }
+
     pub async fn by_backup_configuration_uuid_with_pagination(
         database: &crate::database::Database,
         backup_configuration_uuid: uuid::Uuid,


### PR DESCRIPTION
## Summary

Adds a **Sync to Servers** button directly below the startup commands of an egg. It applies one of the egg's startup commands to every server using that egg in a single action.

Right now, changing an egg's startup command has no effect on existing servers — an admin has to open every server individually and reset its startup command by hand. On an installation with a few hundred servers on the same egg that is not realistic, so eggs and their servers silently drift apart.

## Behaviour

The button sits next to the startup commands it acts on, and opens a modal that asks which command to apply. The select is populated from the egg's own `startup_commands`, so this endpoint cannot be used to push an arbitrary command onto servers.

Applying is deliberately unconditional: every server of the egg ends up on the selected command. The modal says so in an alert, and the submit button is red, because servers running a different command of the same egg and servers with an individually customized startup command are both replaced.

Two details that avoid surprises:

- Servers that already run the selected command are filtered out, so no pointless wings syncs are triggered. Running the sync twice reports `0` the second time.
- Because the modal reads the *saved* egg, it warns and disables submission when the startup commands in the form have unsaved changes — otherwise an admin would sync the previous command without noticing.

Every updated server is pushed to its node afterwards via `batch_sync`, the same call the per-server startup endpoint uses.

## API

```
POST /api/admin/nests/{nest}/eggs/{egg}/sync-startup
{ "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar server.jar" }
→ { "synced": 12 }
```

Requires the `servers.update` admin permission, on top of the `eggs.read` the egg routes already enforce. Returns `417` when the command is not defined on the egg. The action is written to the admin activity log as `nest:egg.sync-startup` with the egg, the command and the number of updated servers.

## Notes

- `Server::all_by_egg_uuid` is new — the existing helpers are paginated, and the full model is needed to sync each server with wings.
- `frontend/public/translations/en.json` also picks up `symlinkName` / `symlinkTarget`, which were already in `translations.ts` but had not been regenerated yet.

## Testing

Verified against a running panel (fresh database, all migrations applied) with four servers on one egg — two on the egg's `Default` command, one on its `Paper` command, one with a custom startup command:

- changing the egg's `Default` command and syncing it updates all four servers and reports `4`
- running the same sync again reports `0`, no servers touched
- a command that is not defined on the egg is rejected with `417`, an empty command with `400`
- unauthenticated returns `401`, a non-admin user returns `401` and leaves the servers unchanged
- the activity log entry is written with the command and the counter
- through the UI: the toast pluralizes correctly (`4 Servers` / `1 Server`), and editing a startup command without saving disables the sync with a warning

`cargo clippy`, `cargo fmt --check` and an offline build against the committed `.sqlx` entry are clean, as are `tsc`, `biome check` and `diff:translations --check`.
