### PR TITLE
Confirm granting admin access

### DIFF
--- a/frontend/public/translations/de.json
+++ b/frontend/public/translations/de.json
@@ -2445,6 +2445,10 @@
                     "title": "Benutzerlöschung bestätigen",
                     "content": "Bist du sicher, dass du **{username}** löschen möchtest?"
                   },
+                  "grantAdmin": {
+                    "title": "Administratorzugriff bestätigen",
+                    "content": "Bist du sicher, dass du **{username}** Administratorzugriff gewähren möchtest? Dieses Konto erhält vollen, uneingeschränkten Zugriff auf alles im Panel."
+                  },
                   "verifyEmail": {
                     "title": "E-Mail als bestätigt markieren",
                     "content": "Möchtest du **{email}** wirklich ohne Bestätigung als verifiziert markieren?",

--- a/frontend/public/translations/en.json
+++ b/frontend/public/translations/en.json
@@ -2446,6 +2446,10 @@
                     "title": "Confirm User Deletion",
                     "content": "Are you sure you want to delete **{username}**?"
                   },
+                  "grantAdmin": {
+                    "title": "Confirm Admin Access",
+                    "content": "Are you sure you want to grant **{username}** admin access? This account will have full, unrestricted access to everything on the panel."
+                  },
                   "verifyEmail": {
                     "title": "Mark Email Verified",
                     "content": "Are you sure you want to mark **{email}** as verified without confirmation?",

--- a/frontend/src/pages/admin/users/UserCreateOrUpdate.tsx
+++ b/frontend/src/pages/admin/users/UserCreateOrUpdate.tsx
@@ -43,8 +43,9 @@ export default function UserCreateOrUpdate({ contextUser }: { contextUser?: z.in
   const editingOtherUser = !!contextUser && contextUser.uuid !== user?.uuid;
 
   const [openModal, setOpenModal] = useState<
-    'delete' | 'disable_two_factor' | 'send_password_reset_email' | 'verify_email' | null
+    'grant_admin' | 'delete' | 'disable_two_factor' | 'send_password_reset_email' | 'verify_email' | null
   >(null);
+  const [confirmStay, setConfirmStay] = useState(false);
 
   const form = useFormEngine<UserFormValues>('admin.users.createOrUpdate', {
     schema: adminUserUpdateSchema.unwrap(),
@@ -64,6 +65,15 @@ export default function UserCreateOrUpdate({ contextUser }: { contextUser?: z.in
   });
 
   useHydrateForm(form, contextUser, userToFormValues);
+
+  const doSave = (stay: boolean) => {
+    if (!contextUser?.admin && form.getValues().admin) {
+      setConfirmStay(stay);
+      setOpenModal('grant_admin');
+    } else {
+      doCreateOrUpdate(stay, queryKeys.admin.users.all());
+    }
+  };
 
   const roles = useSearchableResource<z.infer<typeof roleSchema>>({
     queryKey: queryKeys.admin.roles.all(),
@@ -143,6 +153,20 @@ export default function UserCreateOrUpdate({ contextUser }: { contextUser?: z.in
       titleOrder={2}
     >
       <ConfirmationModal
+        opened={openModal === 'grant_admin'}
+        onClose={() => setOpenModal(null)}
+        title={t('pages.admin.users.tabs.general.page.modal.grantAdmin.title', {})}
+        confirm={t(contextUser ? 'common.button.save' : 'common.button.create', {})}
+        onConfirmed={() => {
+          setOpenModal(null);
+          doCreateOrUpdate(confirmStay, queryKeys.admin.users.all());
+        }}
+      >
+        {t('pages.admin.users.tabs.general.page.modal.grantAdmin.content', {
+          username: form.getValues().username,
+        }).md()}
+      </ConfirmationModal>
+      <ConfirmationModal
         opened={openModal === 'delete'}
         onClose={() => setOpenModal(null)}
         title={t('pages.admin.users.tabs.general.page.modal.delete.title', {})}
@@ -186,7 +210,7 @@ export default function UserCreateOrUpdate({ contextUser }: { contextUser?: z.in
         }).md()}
       </ConfirmationModal>
 
-      <form onSubmit={form.onSubmit(() => doCreateOrUpdate(false, queryKeys.admin.users.all()))}>
+      <form onSubmit={form.onSubmit(() => doSave(false))}>
         <FormEngine form={form} fields={fields} />
 
         <Group mt='md'>
@@ -198,11 +222,7 @@ export default function UserCreateOrUpdate({ contextUser }: { contextUser?: z.in
                 {t('common.button.save', {})}
               </Button>
               {!contextUser && (
-                <Button
-                  onClick={() => doCreateOrUpdate(true, queryKeys.admin.users.all())}
-                  disabled={!form.isValid()}
-                  loading={loading}
-                >
+                <Button onClick={() => doSave(true)} disabled={!form.isValid()} loading={loading}>
                   {t('common.button.saveAndStay', {})}
                 </Button>
               )}

--- a/frontend/src/pages/admin/users/UserCreateOrUpdate.tsx
+++ b/frontend/src/pages/admin/users/UserCreateOrUpdate.tsx
@@ -158,8 +158,8 @@ export default function UserCreateOrUpdate({ contextUser }: { contextUser?: z.in
         title={t('pages.admin.users.tabs.general.page.modal.grantAdmin.title', {})}
         confirm={t(contextUser ? 'common.button.save' : 'common.button.create', {})}
         onConfirmed={() => {
-          setOpenModal(null);
           doCreateOrUpdate(confirmStay, queryKeys.admin.users.all());
+          setOpenModal(null);
         }}
       >
         {t('pages.admin.users.tabs.general.page.modal.grantAdmin.content', {

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -2385,6 +2385,11 @@ const baseTranslations = defineTranslations({
                     title: 'Confirm User Deletion',
                     content: 'Are you sure you want to delete **{username}**?',
                   },
+                  grantAdmin: {
+                    title: 'Confirm Admin Access',
+                    content:
+                      'Are you sure you want to grant **{username}** admin access? This account will have full, unrestricted access to everything on the panel.',
+                  },
                   verifyEmail: {
                     title: 'Mark Email Verified',
                     content: 'Are you sure you want to mark **{email}** as verified without confirmation?',


### PR DESCRIPTION
When admins are creating account while being tired, it can happen that they miss click and select admin creating incorrectly configured account, this is suppose to help prevent that by showing basic modal asking if they want to create an admin account