### PR TITLE
fix: preserve file browser state after uploads

### DIFF
--- a/frontend/src/pages/server/files/tree/FileTree.tsx
+++ b/frontend/src/pages/server/files/tree/FileTree.tsx
@@ -8,7 +8,6 @@ import loadDirectory from '@/api/server/files/loadDirectory.ts';
 import searchFiles from '@/api/server/files/searchFiles.ts';
 import Card from '@/elements/data-display/Card.tsx';
 import ContextMenu from '@/elements/overlays/ContextMenu.tsx';
-import { registerUploadRefresh } from '@/lib/files/uploadManager.ts';
 import { useDraggedFileMove } from '@/pages/server/files/hooks/useDraggedFileMove.ts';
 import { getFilesFromDataTransfer } from '@/pages/server/files/hooks/useFileDragAndDrop.ts';
 import FileMassContextMenu from '@/pages/server/files/list/FileMassContextMenu.tsx';
@@ -177,6 +176,7 @@ function FileTree({
       const loadingKey = `${requestServerUuid}:${directory}`;
       if (loadingDirectoriesRef.current.has(loadingKey)) return;
 
+      const lastPage = page === 1 ? Math.max(1, directoriesRef.current[directory]?.page ?? 1) : page;
       loadingDirectoriesRef.current.add(loadingKey);
       setDirectories((current) => {
         const previous = current[directory] ?? EMPTY_DIRECTORY_STATE;
@@ -185,7 +185,6 @@ function FileTree({
           ...current,
           [directory]: {
             ...previous,
-            entries: page === 1 ? [] : previous.entries,
             loading: true,
             error: null,
           },
@@ -193,12 +192,22 @@ function FileTree({
       });
 
       try {
-        const response = await loadDirectory(requestServerUuid, directory, page, 'name_asc');
+        let response = await loadDirectory(requestServerUuid, directory, page, 'name_asc');
+        const refreshedEntries = [...response.entries.data];
+
+        // Keep the displayed rows until every previously loaded page has been refreshed.
+        for (let nextPage = page + 1; nextPage <= lastPage; nextPage++) {
+          if (activeServerRef.current !== requestServerUuid) return;
+          if (refreshedEntries.length >= response.entries.total) break;
+          response = await loadDirectory(requestServerUuid, directory, nextPage, 'name_asc');
+          refreshedEntries.push(...response.entries.data);
+        }
+
         if (activeServerRef.current === requestServerUuid) {
           setDirectories((current) => {
             const existingEntries = page === 1 ? [] : (current[directory]?.entries ?? []);
             const entriesByName = new Map(existingEntries.map((entry) => [entry.name, entry]));
-            for (const entry of response.entries.data) entriesByName.set(entry.name, entry);
+            for (const entry of refreshedEntries) entriesByName.set(entry.name, entry);
 
             return {
               ...current,
@@ -228,8 +237,9 @@ function FileTree({
           }));
           addToast(message, 'error');
         }
+      } finally {
+        loadingDirectoriesRef.current.delete(loadingKey);
       }
-      loadingDirectoriesRef.current.delete(loadingKey);
     },
     [server.uuid, addToast],
   );
@@ -270,17 +280,6 @@ function FileTree({
       if (!directoriesRef.current[path]) void loadPage(path, 1);
     }
   }, [initialDirectory, loadPage]);
-
-  useEffect(
-    () =>
-      registerUploadRefresh(`server:${server.uuid}`, () => {
-        const paths = [ROOT_DIRECTORY, ...expandedDirectoriesRef.current].filter(
-          (path) => !!directoriesRef.current[path],
-        );
-        for (const path of paths) void loadPage(path, 1);
-      }),
-    [server.uuid, loadPage],
-  );
 
   useEffect(() => store.getState().registerRefreshListener(() => reloadTreeRef.current()), [store]);
   useEffect(
@@ -896,18 +895,12 @@ function FileTree({
     [canUpdateFiles, dragDisabled, getDirectoryCapabilities, getSelectedItems, setHorizontalDragScrollLocked, store],
   );
 
-  const refreshDirectories = (paths: string[]) => {
-    for (const path of new Set(paths)) void loadPage(path, 1);
-    store.getState().invalidateFilemanager(false);
-  };
-
   const uploadDroppedFiles = async (dataTransfer: DataTransfer, target: string) => {
     try {
       const files = await getFilesFromDataTransfer(dataTransfer);
       if (files.length === 0) return;
 
       await store.getState().fileUploader.uploadFilesToDirectory(target, files);
-      refreshDirectories([target]);
     } catch (error) {
       addToast(httpErrorToHuman(error), 'error');
     }

--- a/frontend/src/providers/FileManagerProvider.tsx
+++ b/frontend/src/providers/FileManagerProvider.tsx
@@ -49,6 +49,7 @@ const FileManagerProvider = ({ children }: { children: ReactNode }) => {
     data: infiniteData,
     error: directoryError,
     isFetching,
+    isPlaceholderData,
     isFetchingNextPage,
     hasNextPage,
     fetchNextPage,
@@ -141,8 +142,8 @@ const FileManagerProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => bridgeFileManagerUserSettings(store), [store]);
 
   useEffect(() => {
-    store.setState({ isLoading: isFetching && !isFetchingNextPage });
-  }, [isFetching, isFetchingNextPage]);
+    store.setState({ isLoading: isFetching && (!infiniteData || isPlaceholderData) });
+  }, [isFetching, infiniteData, isPlaceholderData]);
 
   useEffect(() => {
     store.setState({

--- a/frontend/src/stores/fileManager.ts
+++ b/frontend/src/stores/fileManager.ts
@@ -1,4 +1,4 @@
-import { InfiniteData, QueryClient } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { join } from 'pathe';
 import { createRef, RefObject, startTransition } from 'react';
 import { z } from 'zod';
@@ -431,7 +431,7 @@ export const createFileManagerStore = (
       invalidateFilemanager: (notifyListeners = true) => {
         if (notifyListeners) refreshListeners.forEach((listener) => listener());
 
-        const { searchInfo, browsingDirectory, sortMode, doSelectFiles, clearActingFiles, externals } = get();
+        const { searchInfo, doSelectFiles, clearActingFiles, externals } = get();
         const { serverUuid, queryClient } = externals;
 
         queryClient
@@ -466,19 +466,6 @@ export const createFileManagerStore = (
 
           return;
         }
-
-        let trimmed = false;
-        queryClient.setQueryData<InfiniteData<DirectoryResponse, number>>(
-          queryKeys.server(serverUuid).files.directory(browsingDirectory, sortMode),
-          (data) => {
-            if (!data || data.pages.length <= 1) return data;
-
-            trimmed = true;
-            return { pages: data.pages.slice(0, 1), pageParams: data.pageParams.slice(0, 1) };
-          },
-        );
-
-        if (trimmed) window.scrollTo({ top: 0 });
 
         queryClient
           .invalidateQueries({


### PR DESCRIPTION
## Summary

Uploading files clears the tree's directory entries and reloads only the first page, hiding expanded descendants and moving the viewport back up. The list view also discards additional pages and explicitly scrolls to the top.

Keep existing tree rows visible while refreshing all previously loaded pages, then replace each directory's entries together. Preserve cached pages in the list view and show its loading state only for initial loading or navigation. Remove duplicate tree upload refreshes; upload completion already notifies the file manager's refresh listeners.

## Related issue / discussion

Reported by a user frequently uploading resource pack files into expanded, paginated folders.

## Type of change

- [x] Bug fix

## Testing

- `pnpm exec tsc --noEmit` passed in the source workspace.
- Targeted `pnpm exec biome check` passed for all three changed files.
- Exercised the actual directory-loading callback with mocked responses for five scenarios: atomic refresh across multiple pages, request failure retaining existing rows, fewer pages after deletion, loading the next page, and switching servers during a request.
- `git diff --check` passed after applying the patch to upstream `main`.
- Browser verification is still pending. Open nested folders, use "Load more", scroll down, and upload files through the picker or drag and drop. Expanded folders and loaded pages should remain visible throughout the refresh, without a forced scroll to the top.

## Checklist

- Backend, translations, and database checks are not applicable.
- Frontend formatting and lint checks passed for the changed files; the full `pnpm biome:validate` suite was not run.
